### PR TITLE
Chore [Crew] [Worker] Update Code Comment

### DIFF
--- a/worker/crew.go
+++ b/worker/crew.go
@@ -62,6 +62,8 @@ func CrewWorker(ctx context.Context, clientset *kubernetes.Clientset, shipsnames
 // It is expected to return an error if the task cannot be completed successfully, which triggers the retry logic.
 func performTask(ctx context.Context, clientset *kubernetes.Clientset, shipsnamespace string) error {
 	// Task implementation goes here
+	// Note: Currently unimplemented, not ready yet unless you want to implement it as expert.
+	// Tip implementation: use go rountine to run this function in command module, call the captain jack sparrow to run this function.
 	// Return nil if successful, or an error if something goes wrong
 	return nil
 }


### PR DESCRIPTION
- [+] chore(crew.go): add comment indicating that the performTask function is currently unimplemented and provide tips for implementation


Reason:
error stack trace zap logger `zap.NewProduction()` so bad, unlike  `zap.NewDevelopment()`

Example if already implemented using `zap.NewDevelopment()`:
```sh
2023-12-22T04:14:23.954+0700    INFO    navigator/logger.go:34  🤖 Fetching pods        {"crew_worker_unit": 0, "sailing": "FetchPods", "shipsnamespace": "default"}
2023-12-22T04:14:23.968+0700    ERROR   navigator/logger.go:47  🤖 Failed to list pods  {"crew_worker_unit": 0, "sailing": "FetchPods", "shipsnamespace": "default"}
2023-12-22T04:14:23.969+0700    ERROR   navigator/logger.go:47  ❌ Error during task, attempt 1/3: Get "https://127.0.0.1/api/v1/namespaces/default/pods": getting credentials: exec: executable gke-gcloud-auth-plugin.exe not found
```

it will keep trying if got something error