### PR TITLE
Refactor [Navigator] Logger

### DIFF
--- a/navigator/logger.go
+++ b/navigator/logger.go
@@ -28,34 +28,36 @@ var mu sync.Mutex
 // SetLogger sets the logger instance for the package in a thread-safe manner.
 func SetLogger(logger *zap.Logger) {
 	mu.Lock()
-	defer mu.Unlock()
 	Logger = logger
+	mu.Unlock()
 }
 
 // LogInfoWithEmoji logs an informational message with a given emoji, context, and fields.
 // It checks if the Logger is not nil before logging to prevent panics.
 func LogInfoWithEmoji(emoji string, context string, fields ...zap.Field) {
 	mu.Lock()
-	defer mu.Unlock()
+	logger := Logger
+	mu.Unlock()
 
-	if Logger == nil {
+	if logger == nil {
 		fmt.Printf(language.ErrorLoggerIsNotSet, context)
 		return
 	}
-	Logger.Info(emoji+" "+context, fields...)
+	logger.Info(emoji+" "+context, fields...)
 }
 
 // logErrorWithEmoji logs an error message with a given emoji, context, and fields.
 // It checks if the Logger is not nil before logging to prevent panics.
 func LogErrorWithEmoji(emoji string, context string, fields ...zap.Field) {
 	mu.Lock()
-	defer mu.Unlock()
+	logger := Logger
+	mu.Unlock()
 
-	if Logger == nil {
+	if logger == nil {
 		fmt.Printf(language.ErrorLoggerIsNotSet, context)
 		return
 	}
-	Logger.Error(emoji+" "+context, fields...)
+	logger.Error(emoji+" "+context, fields...)
 }
 
 // WithAnyZapField creates a LogFieldOption that encapsulates a zap.Field for deferred addition to a log entry.


### PR DESCRIPTION
- [+] fix(logger.go): unlock mutex before returning in SetLogger function
- [+] refactor(logger.go): store logger instance in a local variable before unlocking mutex in LogInfoWithEmoji and LogErrorWithEmoji functions


Better logger + safe from race condition
example when error
```sh
2023-12-23T04:06:55.440+0700    INFO    navigator/logger.go:46  🤖 Fetching pods        {"crew_worker_unit": 0, "sailing": "FetchPods", "shipsnamespace": "default"}
2023-12-23T04:06:55.440+0700    INFO    navigator/logger.go:46  🤖 Fetching pods        {"crew_worker_unit": 0, "crew_worker_unit": 2, "sailing": "FetchPods", "shipsnamespace": "default"}
2023-12-23T04:06:55.440+0700    INFO    navigator/logger.go:46  🤖 Fetching pods        {"crew_worker_unit": 0, "crew_worker_unit": 2, "crew_worker_unit": 1, "sailing": "FetchPods", "shipsnamespace": "default"}
2023-12-23T04:06:55.441+0700    INFO    navigator/logger.go:46  🤖 Fetching pods        {"crew_worker_unit": 0, "crew_worker_unit": 2, "crew_worker_unit": 1, "crew_worker_unit": 3, "sailing": "FetchPods", "shipsnamespace": "default"}
2023-12-23T04:06:55.441+0700    INFO    navigator/logger.go:46  🤖 Fetching pods        {"crew_worker_unit": 0, "crew_worker_unit": 2, "crew_worker_unit": 1, "crew_worker_unit": 3, "crew_worker_unit": 4, "sailing": "FetchPods", "shipsnamespace": "default"}
2023-12-23T04:06:55.442+0700    ERROR   navigator/logger.go:60  🤖 invalid parameters   {"crew_worker_unit": 0, "crew_worker_unit": 2, "crew_worker_unit": 1, "crew_worker_unit": 3, "crew_worker_unit": 4, "sailing": "FetchPods", "shipsnamespace": "default"}
2023-12-23T04:06:55.441+0700    ERROR   navigator/logger.go:60  🤖 invalid parameters   {"crew_worker_unit": 0, "crew_worker_unit": 2, "crew_worker_unit": 1, "crew_worker_unit": 3, "crew_worker_unit": 4, "sailing": "FetchPods", "shipsnamespace": "default"}
2023-12-23T04:06:55.441+0700    ERROR   navigator/logger.go:60  🤖 invalid parameters   {"crew_worker_unit": 0, "crew_worker_unit": 2, "crew_worker_unit": 1, "crew_worker_unit": 3, "crew_worker_unit": 4, "sailing": "FetchPods", "shipsnamespace": "default"}
2023-12-23T04:06:55.442+0700    ERROR   navigator/logger.go:60  🤖 invalid parameters   {"crew_worker_unit": 0, "crew_worker_unit": 2, "crew_worker_unit": 1, "crew_worker_unit": 3, "crew_worker_unit": 4, "sailing": "FetchPods", "shipsnamespace": "default"}
2023-12-23T04:06:55.442+0700    ERROR   navigator/logger.go:60  🤖 invalid parameters   {"crew_worker_unit": 0, "crew_worker_unit": 2, "crew_worker_unit": 1, "crew_worker_unit": 3, "crew_worker_unit": 4, "sailing": "FetchPods", "shipsnamespace": "default"}
2023-12-23T04:06:55.443+0700    ERROR   navigator/logger.go:60  ❌ Error during task, attempt 1/1: invalid parameters: labelSelector, fieldSelector, or limit   {"crew_worker_unit": 0, "crew_worker_unit": 2, "crew_worker_unit": 1, "crew_worker_unit": 3, "crew_worker_unit": 4, "TaskName": "list-specific-pods", "error": "invalid parameters: labelSelector, fieldSelector, or limit"}
2023-12-23T04:06:55.444+0700    ERROR   navigator/logger.go:60  ❌ Error during task, attempt 1/1: invalid parameters: labelSelector, fieldSelector, or limit   {"crew_worker_unit": 0, "crew_worker_unit": 2, "crew_worker_unit": 1, "crew_worker_unit": 3, "crew_worker_unit": 4, "TaskName": "list-specific-pods", "error": "invalid parameters: labelSelector, fieldSelector, or limit"}
2023-12-23T04:06:55.445+0700    ERROR   navigator/logger.go:60  ❌ Error during task, attempt 1/1: invalid parameters: labelSelector, fieldSelector, or limit   {"crew_worker_unit": 0, "crew_worker_unit": 2, "crew_worker_unit": 1, "crew_worker_unit": 3, "crew_worker_unit": 4, "TaskName": "list-specific-pods", "error": "invalid parameters: labelSelector, fieldSelector, or limit"}
2023-12-23T04:06:55.446+0700    ERROR   navigator/logger.go:60  ❌ Error during task, attempt 1/1: invalid parameters: labelSelector, fieldSelector, or limit   {"crew_worker_unit": 0, "crew_worker_unit": 2, "crew_worker_unit": 1, "crew_worker_unit": 3, "crew_worker_unit": 4, "TaskName": "list-specific-pods", "error": "invalid parameters: labelSelector, fieldSelector, or limit"}
2023-12-23T04:06:55.447+0700    ERROR   navigator/logger.go:60  ❌ Error during task, attempt 1/1: invalid parameters: labelSelector, fieldSelector, or limit   {"crew_worker_unit": 0, "crew_worker_unit": 2, "crew_worker_unit": 1, "crew_worker_unit": 3, "crew_worker_unit": 4, "TaskName": "list-specific-pods", "error": "invalid parameters: labelSelector, fieldSelector, or limit"}
2023-12-23T04:06:57.447+0700    ERROR   navigator/logger.go:60  ❌ Failed to complete task list-specific-pods after 1 attempts  {"crew_worker_unit": 0, "crew_worker_unit": 2, "crew_worker_unit": 1, "crew_worker_unit": 3, "crew_worker_unit": 4, "shipsnamespace": "default", "TaskName": "list-specific-pods", "error": "Failed to complete task list-specific-pods after 1 attempts"}
2023-12-23T04:06:57.448+0700    INFO    K8sBlackPearl/debug.go:68       Received result: Failed to complete task list-specific-pods after 1 attempts
2023-12-23T04:06:57.448+0700    ERROR   navigator/logger.go:60  ❌ Failed to complete task list-specific-pods after 1 attempts  {"crew_worker_unit": 0, "crew_worker_unit": 2, "crew_worker_unit": 1, "crew_worker_unit": 3, "crew_worker_unit": 4, "shipsnamespace": "default", "TaskName": "list-specific-pods", "error": "Failed to complete task list-specific-pods after 1 attempts"}
2023-12-23T04:06:57.448+0700    INFO    K8sBlackPearl/debug.go:68       Received result: Failed to complete task list-specific-pods after 1 attempts
2023-12-23T04:06:57.448+0700    ERROR   navigator/logger.go:60  ❌ Failed to complete task list-specific-pods after 1 attempts  {"crew_worker_unit": 0, "crew_worker_unit": 2, "crew_worker_unit": 1, "crew_worker_unit": 3, "crew_worker_unit": 4, "shipsnamespace": "default", "TaskName": "list-specific-pods", "error": "Failed to complete task list-specific-pods after 1 attempts"}
2023-12-23T04:06:57.449+0700    INFO    K8sBlackPearl/debug.go:68       Received result: Failed to complete task list-specific-pods after 1 attempts
2023-12-23T04:06:57.449+0700    ERROR   navigator/logger.go:60  ❌ Failed to complete task list-specific-pods after 1 attempts  {"crew_worker_unit": 0, "crew_worker_unit": 2, "crew_worker_unit": 1, "crew_worker_unit": 3, "crew_worker_unit": 4, "shipsnamespace": "default", "TaskName": "list-specific-pods", "error": "Failed to complete task list-specific-pods after 1 attempts"}
2023-12-23T04:06:57.449+0700    INFO    K8sBlackPearl/debug.go:68       Received result: Failed to complete task list-specific-pods after 1 attempts
2023-12-23T04:06:57.450+0700    ERROR   navigator/logger.go:60  ❌ Failed to complete task list-specific-pods after 1 attempts  {"crew_worker_unit": 0, "crew_worker_unit": 2, "crew_worker_unit": 1, "crew_worker_unit": 3, "crew_worker_unit": 4, "shipsnamespace": "default", "TaskName": "list-specific-pods", "error": "Failed to complete task list-specific-pods after 1 attempts"}
2023-12-23T04:06:57.451+0700    INFO    K8sBlackPearl/debug.go:68       Received result: Failed to complete task list-specific-pods after 1 attempts
2023-12-23T04:06:57.451+0700    INFO    K8sBlackPearl/debug.go:68       Received result: Failed to complete task list-specific-pods after 1 attempts
2023-12-23T04:19:21.252+0700    INFO    K8sBlackPearl/debug.go:74       Shutdown signal received
2023-12-23T04:19:26.258+0700    INFO    K8sBlackPearl/debug.go:81       All workers have been shut down. Exiting.
```