### PR TITLE
Fix [Task Crew] [Scale Deployment] [Logs] Constant

### DIFF
--- a/language/init_const.go
+++ b/language/init_const.go
@@ -41,6 +41,7 @@ const (
 	FailedToScaleDeployment                = "Failed to scale deployment '%s' to '%d' after %d retries: %v"
 	FailedTOScallEdDeployment              = "Failed to scale deployment '%s' to '%d': %v"
 	FailedToGetDeployment                  = "Failed to get deployment '%s': %v"
+	ErrorFailedtoScalingDeployment         = "Failed to scale deployment"
 )
 
 const (
@@ -76,6 +77,8 @@ const (
 	Worker_Name           = "crew_worker"
 	TaskLabelPods         = "WriteLabelPods"
 	TaskManageDeployments = "ManageDeployments"
+	TaskScaleDeployment   = "ScaleDeployment"
+	ScalingDeployment     = "Crew Worker %d: Scaling deployments"
 	ManagingDeployments   = "Crew Worker %d: Managing deployments"
 )
 

--- a/worker/tasks_crew.go
+++ b/worker/tasks_crew.go
@@ -199,13 +199,13 @@ type CrewScaleDeployments struct {
 func (c *CrewScaleDeployments) Run(ctx context.Context, clientset *kubernetes.Clientset, shipsNamespace string, taskName string, parameters map[string]interface{}, workerIndex int) error {
 	// Use the provided logging pattern
 	fields := navigator.CreateLogFields(
-		language.TaskManageDeployments,
+		language.TaskScaleDeployment,
 		shipsNamespace,
 		navigator.WithAnyZapField(zap.String(language.Task_Name, taskName)),
 	)
 	navigator.LogInfoWithEmoji(
 		language.PirateEmoji,
-		fmt.Sprintf(language.ManagingDeployments, workerIndex),
+		fmt.Sprintf(language.ScalingDeployment, workerIndex),
 		fields...,
 	)
 
@@ -234,7 +234,8 @@ func (c *CrewScaleDeployments) Run(ctx context.Context, clientset *kubernetes.Cl
 	if err != nil {
 		// Log the error with the custom logging function
 		errorFields := append(fields, zap.String(language.Error, err.Error()))
-		navigator.LogErrorWithEmojiRateLimited(language.PirateEmoji, language.ErrorScalingDeployment, errorFields...)
+		failedMessage := fmt.Sprintf("%v %s", constant.ErrorEmoji, language.ErrorFailedtoScalingDeployment)
+		navigator.LogErrorWithEmojiRateLimited(language.PirateEmoji, failedMessage, errorFields...)
 		return err
 	}
 


### PR DESCRIPTION
- [+] fix(init_const.go): add new error constant for failed scaling deployment
- [+] fix(tasks_crew.go): change task name from TaskManageDeployments to TaskScaleDeployment
- [+] fix(tasks_crew.go): change log message from ManagingDeployments to ScalingDeployment
- [+] fix(tasks_crew.go): change error message from ErrorScalingDeployment to ErrorFailedtoScalingDeployment