### PR TITLE
Refactor Code Base & Pass Context to Retry Policy Logic

### DIFF
--- a/language/init_const.go
+++ b/language/init_const.go
@@ -19,7 +19,7 @@ const (
 	ErrorFailedToComplete                  = "Failed to complete task after %d attempts"
 	ContextCancelledAbort                  = "Context cancelled, aborting retries."
 	ContextCancelled                       = "Context cancelled"
-	ErrorDuringTaskAttempt                 = "Error during task, attempt %d/%d: %v"
+	ErrorDuringTaskAttempt                 = "%s Error during task, attempt %d/%d: %v"
 	UnknownTaskType                        = "unknown task type: %s"
 	InvalidParameters                      = "invalid parameters"
 	InvalidparametersL                     = "invalid parameters: labelSelector, fieldSelector, or limit"
@@ -167,6 +167,8 @@ const (
 	PirateEmoji  = "🏴‍☠️ "
 	SwordEmoji   = "⚔️ "
 	CompassEmoji = "🧭 "
+	RetryEmoji   = "🔄 "
+	WarningEmoji = "⚠️ "
 )
 
 const (

--- a/worker/error_and_retry.go
+++ b/worker/error_and_retry.go
@@ -14,6 +14,71 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
+// performTaskWithRetries tries to execute a task, with retries on failure.
+// It honors the cancellation signal from the context and ceases retry attempts
+// if the context is cancelled. If the task remains incomplete after all retries,
+// it returns an error detailing the failure.
+//
+// Parameters:
+//
+//	ctx context.Context: Context for task cancellation and timeouts.
+//	clientset *kubernetes.Clientset: Kubernetes API client for executing tasks.
+//	shipsNamespace string: Kubernetes namespace for task execution.
+//	task configuration.Task: Task to be executed.
+//	results chan<- string: Channel for reporting task execution results.
+//	workerIndex int: Index of the worker for contextual logging.
+//	taskStatus *TaskStatusMap: Map to track and control the status of tasks.
+//
+// Returns:
+//
+//	error: Error if the task fails after all retry attempts.
+func performTaskWithRetries(ctx context.Context, clientset *kubernetes.Clientset, shipsNamespace string, task configuration.Task, results chan<- string, workerIndex int, taskStatus *TaskStatusMap) error {
+	// Define the operation to be retried.
+	operation := func() (string, error) {
+		// Attempt to perform the task.
+		err := performTask(ctx, clientset, shipsNamespace, task, workerIndex)
+		return task.Name, err // Return the task name along with the error.
+	}
+
+	// Create a RetryPolicy instance with the task's retry settings.
+	retryPolicy := RetryPolicy{
+		MaxRetries: task.MaxRetries,
+		RetryDelay: task.RetryDelayDuration,
+	}
+
+	// Use the RetryPolicy's Execute method to perform the operation with retries.
+	err := retryPolicy.Execute(ctx, operation, func(message string, fields ...zap.Field) {
+		// This is a placeholder for the actual logging function.
+		// Replace this with the actual function to log retries.
+		// For example: navigator.LogInfoWithEmoji or navigator.LogErrorWithEmoji
+		// Combine emojis with a space for readability.
+		emojiField := fmt.Sprintf("%s %s", constant.ErrorEmoji, language.PirateEmoji)
+		navigator.LogErrorWithEmoji(emojiField, message, fields...)
+	})
+
+	if err != nil {
+		// Additional error handling logic
+		if apierrors.IsConflict(err) {
+			// Handle conflict-specific errors
+			conflictResolved := handleConflictError(ctx, clientset, shipsNamespace, &task)
+			if conflictResolved {
+				// Conflict resolved, retry the operation
+				return performTaskWithRetries(ctx, clientset, shipsNamespace, task, results, workerIndex, taskStatus)
+			}
+		} else {
+			// Handle generic errors that are not conflicts
+			handleGenericError(ctx, err, task.MaxRetries, &task, workerIndex, task.MaxRetries, task.RetryDelayDuration)
+		}
+
+		handleFailedTask(task, taskStatus, shipsNamespace, err, results, workerIndex)
+		return fmt.Errorf(language.ErrorFailedToCompleteTask, task.Name, task.MaxRetries)
+	}
+
+	// If the operation was successful, handle the success.
+	handleSuccessfulTask(task, results, workerIndex)
+	return nil
+}
+
 // logRetryAttempt logs a warning message indicating a task retry attempt with the current count.
 // It includes the task name and the error that prompted the retry. The maxRetries variable is used
 // to indicate the total number of allowed retries.
@@ -29,7 +94,7 @@ func logRetryAttempt(taskName string, attempt int, err error, maxRetries int, lo
 	message := fmt.Sprintf(language.ErrorDuringTaskAttempt, attempt+1, maxRetries, err)
 	fields := []zap.Field{
 		zap.String(tasK, taskName),
-		zap.Int(attempT, attempt+1),
+		zap.Int(attempT, attempt),
 		zap.Int(maXRetries, maxRetries),
 		zap.Error(err),
 	}
@@ -77,6 +142,9 @@ func logFinalError(shipsnamespace string, taskName string, err error, maxRetries
 // Returns:
 //
 //	shouldContinue bool: A boolean indicating whether the task should be retried or not.
+//
+// Deprecated: Already Sync with Retry Policy which is better for reduce complex and free resource channel for go routines (known as gopher).
+// so this function are not longer used.
 func handleTaskError(ctx context.Context, clientset *kubernetes.Clientset, shipsnamespace string, err error, attempt int, task *configuration.Task, workerIndex int, maxRetries int, retryDelay time.Duration) (shouldContinue bool) {
 	if ctx.Err() != nil {
 		return false
@@ -130,7 +198,7 @@ func handleConflictError(ctx context.Context, clientset *kubernetes.Clientset, s
 //
 //	bool: A boolean indicating whether the task should be retried or not.
 func handleGenericError(ctx context.Context, err error, attempt int, task *configuration.Task, workerIndex int, maxRetries int, retryDelay time.Duration) bool {
-	logRetryAttempt(task.Name, attempt, err, maxRetries, navigator.Logger.Error)
+	logRetryAttempt(task.Name, attempt, err, maxRetries, navigator.Logger.Info)
 
 	// Wait for the next attempt, respecting the context cancellation.
 	if !waitForNextAttempt(ctx, retryDelay) {

--- a/worker/helper.go
+++ b/worker/helper.go
@@ -52,7 +52,8 @@ func (r *RetryPolicy) Execute(ctx context.Context, operation func() (string, err
 			return nil // The operation was successful, return nil error.
 		}
 		lastErr = err
-		logRetryAttempt(taskName, attempt, err, r.MaxRetries, logFunc)
+		// Pass Context to logRetryAttempt.
+		logRetryAttempt(taskName, attempt, r.MaxRetries, err, logFunc)
 		if attempt < r.MaxRetries-1 {
 			if !waitForNextAttempt(ctx, r.RetryDelay) {
 				return ctx.Err() // Context was cancelled, return the context error.


### PR DESCRIPTION
it's connected now include handling conflict of k8s
### Deadcode (unused)
```sh
$ deadcode .
navigator\logger.go:83:6: unreachable func: LogInfoWithEmojiRateLimited
worker\crew.go:130:6: unreachable func: CrewProcessPods
worker\error_and_retry.go:164:6: unreachable func: handleTaskError
worker\labels_pods.go:195:6: unreachable func: labelSinglePod
worker\track_task.go:50:25: unreachable func: TaskStatusMap.AddTask
worker\track_task.go:70:25: unreachable func: TaskStatusMap.GetTask
worker\track_task.go:86:25: unreachable func: TaskStatusMap.UpdateTask
worker\track_task.go:101:25: unreachable func: TaskStatusMap.DeleteTask
worker\track_task.go:155:25: unreachable func: TaskStatusMap.GetAllTasks
worker\track_task.go:178:25: unreachable func: TaskStatusMap.IsClaimed
```

### Recent Used:
```sh
$ gocyclo -avg worker
5 worker (*CrewCreatePVCStorage).Run worker\tasks_crew.go:334:1
5 worker (*CrewUpdateImageDeployments).Run worker\tasks_crew.go:272:1
5 worker (*CrewProcessCheckHealthTask).logResults worker\logs_pods.go:99:1
5 worker (*RetryPolicy).Execute worker\helper.go:47:1
4 worker extractNetworkPolicyParameters worker\update_network_policy.go:124:1
4 worker extractDeploymentParameters worker\update_image.go:119:1
4 worker updateDeploymentImageOnce worker\update_image.go:71:1
4 worker UpdateDeploymentImage worker\update_image.go:35:1
4 worker (*CrewUpdateNetworkPolicy).Run worker\tasks_crew.go:384:1
4 worker (*CrewScaleDeployments).extractScaleParameters worker\tasks_crew.go:221:1
4 worker ScaleDeployment worker\scale.go:37:1
4 worker (*CrewProcessCheckHealthTask).checkHealthWorker worker\logs_pods.go:71:1
4 worker getListOptions worker\list_options.go:20:1
4 worker LabelPods worker\labels_pods.go:163:1
4 worker getParamAsInt worker\helper.go:128:1
4 worker performTaskWithRetries worker\error_and_retry.go:36:1
4 worker CrewCheckingisPodHealthy worker\crew.go:168:1
3 worker unmarshalPolicySpec worker\update_network_policy.go:102:1
3 worker extractPolicyName worker\update_network_policy.go:83:1
3 worker UpdateNetworkPolicy worker\update_network_policy.go:36:1
3 worker (*CrewScaleDeployments).Run worker\tasks_crew.go:192:1
3 worker (*CrewLabelPodsTaskRunner).Run worker\tasks_crew.go:140:1
3 worker (*CrewProcessCheckHealthTask).Run worker\tasks_crew.go:109:1
3 worker (*CrewGetPodsTaskRunner).Run worker\tasks_crew.go:78:1
3 worker NewKubernetesClient worker\setup.go:22:1
3 worker scaleDeploymentOnce worker\scale.go:83:1
3 worker extractLabelParameters worker\labels_pods.go:236:1
3 worker updatePodLabels worker\labels_pods.go:93:1
3 worker labelSinglePodWithResourceVersion worker\labels_pods.go:30:1
3 worker waitForNextAttempt worker\helper.go:200:1
3 worker getParamAsInt64 worker\helper.go:89:1
3 worker resolveConflict worker\crew.go:110:1
3 worker processTask worker\crew.go:52:1
3 configuration ParseDuration worker\configuration\task.go:131:1
3 configuration LoadTasks worker\configuration\task.go:117:1
3 configuration parseTasks worker\configuration\task.go:97:1
3 configuration LoadTasksFromYAML worker\configuration\task.go:74:1
3 configuration LoadTasksFromJSON worker\configuration\task.go:47:1
2 worker (*TaskStatusMap).GetAllTasks worker\track_task.go:155:1
2 worker (*TaskStatusMap).Claim worker\track_task.go:122:1
2 worker performTask worker\tasks_crew.go:434:1
2 worker getLatestVersionOfPod worker\tasks_crew.go:423:1
2 worker GetTaskRunner worker\tasks_crew.go:61:1
2 worker buildOutOfClusterConfig worker\setup.go:48:1
2 worker createPVC worker\pvc_storage.go:26:1
2 worker logPods worker\logs_pods.go:22:1
2 worker listPods worker\list_pods.go:29:1
2 worker getUpdatedLabels worker\labels_pods.go:125:1
2 worker logResultsFromChannel worker\helper.go:186:1
2 worker getParamAsString worker\helper.go:73:1
2 worker handleGenericError worker\error_and_retry.go:216:1
2 worker handleConflictError worker\error_and_retry.go:191:1
2 worker logRetryAttempt worker\error_and_retry.go:94:1
2 worker CrewWorker worker\crew.go:31:1
2 worker CaptainTellWorkers worker\captain.go:29:1
1 worker reportNetworkFailure worker\update_network_policy.go:73:1
1 worker reportNetworkSuccess worker\update_network_policy.go:64:1
1 worker reportMaxRetriesFailure worker\update_image.go:109:1
1 worker reportFailure worker\update_image.go:100:1
1 worker reportSuccess worker\update_image.go:91:1
1 worker updateImageWithRetry worker\update_image.go:61:1
1 worker (*TaskStatusMap).IsClaimed worker\track_task.go:178:1
1 worker (*TaskStatusMap).Release worker\track_task.go:140:1
1 worker NewTaskStatusMap worker\track_task.go:34:1
1 worker (*CrewScaleDeployments).performScaling worker\tasks_crew.go:254:1
1 worker (*CrewManageDeployments).Run worker\tasks_crew.go:172:1
1 worker RegisterTaskRunner worker\tasks_crew.go:55:1
1 worker (*CrewGetPods).Run worker\tasks_crew.go:42:1
1 worker InitializeTasks worker\tasks_crew.go:21:1
1 worker int32Ptr worker\scale.go:112:1
1 worker (*CrewProcessCheckHealthTask).checkPodsHealth worker\logs_pods.go:55:1
1 worker logPod worker\logs_pods.go:37:1
1 worker wrapPodError worker\labels_pods.go:144:1
1 worker shouldUpdatePod worker\labels_pods.go:73:1
1 worker fetchLatestPodVersion worker\labels_pods.go:57:1
1 worker init worker\init.go:6:1
1 worker logErrorWithFields worker\helper.go:175:1
1 worker createLogFieldsForRunnerTask worker\helper.go:162:1
1 worker logTaskStart worker\helper.go:148:1
1 worker logFinalError worker\error_and_retry.go:130:1
1 worker handleSuccessfulTask worker\crew.go:90:1
1 worker handleFailedTask worker\crew.go:76:1
1 configuration unmarshalYAML worker\configuration\task.go:90:1
1 configuration unmarshalJSON worker\configuration\task.go:63:1
Average: 2.34
```